### PR TITLE
Fix typo to make example run without error

### DIFF
--- a/R/elements.R
+++ b/R/elements.R
@@ -32,7 +32,7 @@
 #'       p("First screen.")
 #'     ),
 #'     screen(
-#'       p("Second screen."),
+#'       p("Second screen.")
 #'     )
 #'   )
 #' )


### PR DESCRIPTION
There was a comma in the wrong place, causing the example to fail...